### PR TITLE
fix: removing node-cleanup, as it has unexpected behavior

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
       - name: install
         run: npm ci
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,18 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, develop]
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,12 +1839,6 @@
       "integrity": "sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng==",
       "dev": true
     },
-    "@types/node-cleanup": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha512-HTksao/sZs9nqxKD/vWOR3WxSrQsyJlBPEFFCgq9lMmhRsuQF+2p6hy+7FaCYn6lOeiDc3ywI8jDQ2bz5y6m8w==",
-      "dev": true
-    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -6323,11 +6317,6 @@
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
-    },
-    "node-cleanup": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw=="
     },
     "node-emoji": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@nestjs/cli": "^9.4.2",
     "@types/jest": "^27.4.1",
     "@types/node": "14",
-    "@types/node-cleanup": "^2.1.2",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "@typescript-eslint/parser": "^5.28.0",
@@ -100,7 +99,6 @@
     "winston": "^3.8.2"
   },
   "dependencies": {
-    "node-cleanup": "^2.1.2",
     "uuid": "^9.0.0"
   }
 }

--- a/src/async-local-storage/request-context.ts
+++ b/src/async-local-storage/request-context.ts
@@ -1,6 +1,5 @@
 import { ContextInfoProvider } from './../types/context-info-provider';
 import { v4 } from 'uuid';
-import * as nodeCleanup from 'node-cleanup';
 import { AsyncLocalStorage } from 'async_hooks';
 
 const onContextEndList: Array<(routine?: string) => void> = [];
@@ -101,8 +100,6 @@ export class AsyncLocalStorageContextProvider<T extends object>
 		}) as Callback;
 	}
 }
-
-nodeCleanup(RequestContext.flush.bind(RequestContext));
 
 export const asyncLocalStorageContextProvider =
 	new AsyncLocalStorageContextProvider();


### PR DESCRIPTION
node-cleanup do a process.exit on uncautghException (https://github.com/jtlapp/node-cleanup/issues/14). This is a no-go and can invalidate any use one can have of this event.

Also, it looks like the package is abandoned, so, it's better to no use it at all. I'll test later other library options to do the flush